### PR TITLE
Update "no-unused-expressions" rule, add test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "7"
+  - "6"

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-await-in-loop': 'off',
     'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
     'no-return-assign': 'off',
+    'no-unused-expressions': ['error', { allowTernary: true }],
     'no-use-before-define': 'off',
     'quote-props': ['error', 'consistent-as-needed'],
     'semi': ['error', 'never'],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.0",
   "description": "Tipsi shared eslint config",
   "main": "index.js",
+  "scripts": {
+    "test": "eslint -c index.js index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/isnifer/eslint-config-tipsi.git"


### PR DESCRIPTION
This rule will not warn something like this:
```js
a ? b() : c()
```