### PR TITLE
Add rule for switch-case

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = {
       functions: 'never',
     }],
     'global-require': 'off',
-    'indent': ['error', 2],
+    'indent': ['error', 2, { SwitchCase: 1 }],
     'no-await-in-loop': 'off',
     'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
     'no-return-assign': 'off',


### PR DESCRIPTION
```js
switch (something) {
  case 'hello':
    return 'world'
  default:
    break;
}
```

instead of:
```js
switch (something) {
case 'hello':
  return 'world'
default:
  break;
}
```