### PR TITLE
Add rule 'no-confusing-arrow'

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = {
     'global-require': 'off',
     'indent': ['error', 2, { SwitchCase: 1 }],
     'no-await-in-loop': 'off',
+    'no-confusing-arrow': 'off',
     'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
     'no-return-assign': 'off',
     'no-unused-expressions': ['error', { allowTernary: true }],


### PR DESCRIPTION
I think this is normal case when we are writing:
```js
const getUser = id => id === viewer.id ? viewer : null

// or
const something = {
  method: id => id === viewer.id ? viewer : null
}
```